### PR TITLE
FIX: File name is longer than the maximum allowed path

### DIFF
--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -114,7 +114,7 @@ class Dom {
 	public function load($str, $options = [])
 	{
 		// check if it's a file
-		if (is_file($str))
+		if (strpos($str, "\n") === FALSE && is_file($str))
 		{
 			return $this->loadFromFile($str, $options);
 		}


### PR DESCRIPTION
PHP Warning: is_file(): File name is longer than the maximum allowed path length on this platform (4096):