### PR TITLE
Fixed Strings example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,35 @@ $dom->load('http://google.com', [
 $dom->load('http://gmail.com'); // will not have whitespaceTextNode set to false.
 ```
 
-At the moment we support 3 options, strict, whitespaceTextNode and enforceEncoding. Strict, by default false, will throw a `StrickException` if it find that the html is not strict complient (all tags must have a clossing tag, no attribute with out a value, etc.). 
+At the moment we support 7 options.
+
+**Strict**
+
+Strict, by default false, will throw a `StrickException` if it find that the html is not strict complient (all tags must have a clossing tag, no attribute with out a value, etc.).
+
+**whitespaceTextNode**
 
 The whitespaceTextNode, by default true, option tells the parser to save textnodes even if the content of the node is empty (only whitespace). Setting it to false will ignore all whitespace only text node found in the document.
 
+**enforceEncoding
+
 The enforceEncoding, by default null, option will enforce an charater set to be used for reading the content and returning the content in that encoding. Setting it to null will trigger an attempt to figure out the encoding from within the content of the string given instead. 
+
+**cleanupInput**
+
+Set this to `true` to skip the entire clean up phase of the parser. If this is set to true the next 3 options will be ignored. Defaults to `false`.
+
+**removeScripts**
+
+Set this to `false` to skip removing the script tags from the document body. This might have adverse effects. Defaults to `true`.
+
+**removeStyles**
+
+Set this to `false` to skip removing of style tags from the document body. This might have adverse effects. Defaults to `true`.
+
+**preserveLineBreaks**
+
+Preserves Line Breaks if set to `true`. If set to `false` line breaks are cleaned up as part of the input clean up process. Defaults to `false`.
 
 Static Facade
 -------------

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Loading a string directly, with out the checks in `load()` is also easely done.
 use PHPHtmlParser\Dom;
 
 $dom = new Dom;
-$dom->loadStr('<html>String</html>', [])
+$dom->loadStr('<html>String</html>', []);
 $html = $dom->outerHtml;
 ```
 

--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -366,7 +366,12 @@ class Dom {
 		}
 
 		// clean out the \n\r
-		$str = str_replace(["\r\n", "\r", "\n"], ' ', $str);
+		$replace = ' ';
+		if ($this->options->get('preserveLineBreaks'))
+		{
+			$replace = '&#10';
+		}
+		$str = str_replace(["\r\n", "\r", "\n"], $replace, $str);
 
 		// strip the doctype
 		$str = mb_eregi_replace("<!doctype(.*?)>", '', $str);

--- a/src/PHPHtmlParser/Dom/TextNode.php
+++ b/src/PHPHtmlParser/Dom/TextNode.php
@@ -39,6 +39,9 @@ class TextNode extends AbstractNode {
 		// remove double spaces
 		$text = mb_ereg_replace('\s+', ' ', $text);
 
+		// restore line breaks
+		$text = str_replace('&#10', "\n", $text);
+
 		$this->text = $text;
 		$this->tag  = new Tag('text');
 		parent::__construct();

--- a/src/PHPHtmlParser/Options.php
+++ b/src/PHPHtmlParser/Options.php
@@ -22,7 +22,8 @@ class Options {
 		'enforceEncoding'    => null,
 		'cleanupInput'       => true,
 		'removeScripts'      => true,
-		'removeStyles'       => true
+		'removeStyles'       => true,
+		'preserveLineBreaks' => false,
 	];
 
 	/**

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -187,6 +187,16 @@ class DomTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals(' <p>Журчанье воды<br /> Черно-белые тени<br /> Вновь на фонтане</p> ', $post->find('.post-message', 0)->innerHtml);
 	}
 
+	public function testLoadFileBigTwicePreserveOption()
+	{
+		$dom = new Dom;
+		$dom->loadFromFile('tests/files/big.html', ['preserveLineBreaks' => true]);
+		$post = $dom->find('.post-row', 0);
+		$this->assertEquals('<p>Журчанье воды<br />
+Черно-белые тени<br />
+Вновь на фонтане</p>', trim($post->find('.post-message', 0)->innerHtml));
+	}
+
 	public function testLoadFromUrl()
 	{
 		$curl = Mockery::mock('PHPHtmlParser\CurlInterface');


### PR DESCRIPTION
Added the missing semicolon in the README example, just to avoid any confusion.