### PR TITLE
Added removeAttribute and removeAttributes methods to Tag class

### DIFF
--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -548,6 +548,34 @@ abstract class AbstractNode
     }
 
     /**
+     * A wrapper method that simply calls the removeAttribute method
+     * on the tag of this node.
+     *
+     * @param string $key
+     * @return $this
+     */
+    public function removeAttribute($key)
+    {
+        $this->tag->removeAttribute($key);
+
+        return $this;
+    }
+
+    /**
+     * A wrapper method that simply calls the removeAttributes method
+     * on the tag of this node.
+     *
+     * @param array $keys
+     * @return $this
+     */
+    public function removeAttributes($keys)
+    {
+        $this->tag->removeAttributes($keys);
+
+        return $this;
+    }
+
+    /**
      * Function to locate a specific ancestor tag in the path to the root.
      *
      * @param  string $tag

--- a/src/PHPHtmlParser/Dom/Tag.php
+++ b/src/PHPHtmlParser/Dom/Tag.php
@@ -204,6 +204,39 @@ class Tag
     }
 
     /**
+     * Removes an attribute for this tag
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function removeAttribute($key)
+    {
+        $key = strtolower($key);
+        unset($this->attr[$key]);
+
+        return $this;
+    }
+
+    /**
+     * Removes all attributes for this tag except the ones in the $keys array
+     *
+     * @param array $keys
+     * @return mixed
+     */
+    public function removeAttributes($keys)
+    {
+        $attributes = $this->getAttributes();
+        foreach($attributes as $key => $attribute) {
+            $key = strtolower($key);
+            if(!in_array($key, $keys)) {
+                unset($this->attr[$key]);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Generates the opening tag for this object.
      *
      * @return string


### PR DESCRIPTION
It would be very useful if were possible to remove an attribute (or a list of attributes) from a tag. This PR adds two new methods both to the AbstractNode and the Tag classes. The first method, removeAttribute, just removes an attributes. The second method, removeAttributes, removes all attributes from a tag except the ones passed to the method.