### PR TITLE
update with full list html5 self closing tags

### DIFF
--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -79,15 +79,23 @@ class Dom
      * @var array
      */
     protected $selfClosing = [
-        'img',
-        'br',
-        'input',
-        'meta',
-        'link',
-        'hr',
+        'area',
         'base',
+        'basefont',
+        'br',
+        'col',
         'embed',
+        'hr',
+        'img',
+        'input',
+        'keygen',
+        'link',
+        'meta',
+        'param',
+        'source',
         'spacer',
+        'track',
+        'wbr'
     ];
 
     /**


### PR DESCRIPTION
html5 spec has a list of void elements (aka self closing tags)
https://www.w3.org/TR/html5/syntax.html#void-elements
