### PR TITLE
added browser agent to curl options

### DIFF
--- a/src/PHPHtmlParser/Curl.php
+++ b/src/PHPHtmlParser/Curl.php
@@ -28,6 +28,11 @@ class Curl implements CurlInterface
 
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_VERBOSE, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36');
+        curl_setopt($ch, CURLOPT_URL, $url);
 
         $content = curl_exec($ch);
         if ($content === false) {


### PR DESCRIPTION
some sites return errors on loadFromUrl() if non-browser User Agent detected
