### PR TITLE
Fix issues with HTML cache and updates

### DIFF
--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -305,6 +305,9 @@ abstract class AbstractNode
     {
         $this->tag->setAttribute($key, $value);
 
+        //clear any cache
+        $this->clear();
+        
         return $this;
     }
 
@@ -318,6 +321,9 @@ abstract class AbstractNode
     public function removeAttribute($key)
     {
         $this->tag->removeAttribute($key);
+        
+        //clear any cache
+        $this->clear();
     }
 
     /**
@@ -329,8 +335,10 @@ abstract class AbstractNode
     public function removeAllAttributes()
     {
         $this->tag->removeAllAttributes();
+        
+        //clear any cache
+        $this->clear();
     }
-
     /**
      * Function to locate a specific ancestor tag in the path to the root.
      *

--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -169,8 +169,8 @@ abstract class AbstractNode
         if ( ! is_null($this->parent)) {
             $this->parent->removeChild($this->id);
         }
-
-        $this->parent = null;
+        $this->parent->clear();
+        $this->clear();
     }
 
     /**
@@ -307,7 +307,7 @@ abstract class AbstractNode
 
         //clear any cache
         $this->clear();
-        
+
         return $this;
     }
 
@@ -321,7 +321,7 @@ abstract class AbstractNode
     public function removeAttribute($key)
     {
         $this->tag->removeAttribute($key);
-        
+
         //clear any cache
         $this->clear();
     }
@@ -335,7 +335,7 @@ abstract class AbstractNode
     public function removeAllAttributes()
     {
         $this->tag->removeAllAttributes();
-        
+
         //clear any cache
         $this->clear();
     }

--- a/src/PHPHtmlParser/Dom/HtmlNode.php
+++ b/src/PHPHtmlParser/Dom/HtmlNode.php
@@ -186,6 +186,9 @@ class HtmlNode extends InnerNode
         $this->innerHtml = null;
         $this->outerHtml = null;
         $this->text      = null;
+        if (is_null($this->parent) === false) {
+            $this->parent->clear();
+        }
     }
 
     /**

--- a/src/PHPHtmlParser/Dom/InnerNode.php
+++ b/src/PHPHtmlParser/Dom/InnerNode.php
@@ -242,6 +242,9 @@ abstract class InnerNode extends ArrayNode
         $this->children                  = array_combine($keys, $this->children);
         $this->children[$newChild->id()] = $newChild;
         unset($oldChild);
+        
+        //clear any cache
+        $this->clear();
     }
 
     /**

--- a/src/PHPHtmlParser/Dom/MockNode.php
+++ b/src/PHPHtmlParser/Dom/MockNode.php
@@ -40,6 +40,9 @@ class MockNode extends InnerNode
         $this->innerHtml = null;
         $this->outerHtml = null;
         $this->text      = null;
+        if (is_null($this->parent) === false) {
+            $this->parent->clear();
+        }
     }
 
     /**

--- a/tests/Node/HtmlTest.php
+++ b/tests/Node/HtmlTest.php
@@ -246,6 +246,39 @@ class NodeHtmlTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('<div class="all"><a href=\'http://google.com\' ui-view>link</a><br /></div>', $parent->outerHtml);
     }
 
+    public function testOuterHtmlWithChanges()
+    {
+        $div = new Tag('div');
+        $div->setAttributes([
+            'class' => [
+                'value'       => 'all',
+                'doubleQuote' => true,
+            ],
+        ]);
+        $a = new Tag('a');
+        $a->setAttributes([
+            'href' => [
+                'value'       => 'http://google.com',
+                'doubleQuote' => false,
+            ],
+        ]);
+        $br = new Tag('br');
+        $br->selfClosing();
+
+        $parent  = new HtmlNode($div);
+        $childa  = new HtmlNode($a);
+        $childbr = new HtmlNode($br);
+        $parent->addChild($childa);
+        $parent->addChild($childbr);
+        $childa->addChild(new TextNode('link'));
+
+        $this->assertEquals('<div class="all"><a href=\'http://google.com\'>link</a><br /></div>', $parent->outerHtml());
+        
+        $childa->setAttribute('href', 'https://www.google.com');
+        
+        $this->assertEquals('<a href="https://www.google.com">link</a>', $childa->outerHtml());
+    }
+
     public function testText()
     {
         $a    = new Tag('a');

--- a/tests/Node/TagTest.php
+++ b/tests/Node/TagTest.php
@@ -68,6 +68,30 @@ class NodeTagTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('funtimes', $tag->class['value']);
     }
 
+    public function testUpdateAttributes()
+    {
+        $tag = new Tag('a');
+        $tag->setAttributes([
+            'href' => [
+                'value'       => 'http://google.com',
+                'doubleQuote' => false,
+            ],
+        ]);
+
+        $this->assertEquals(null, $tag->class['value']);
+        $this->assertEquals('http://google.com', $tag->href['value']);
+
+
+        $attr = [
+            'href'  => 'https://www.google.com',
+            'class' => 'funtimes',
+        ];
+
+        $tag->setAttributes($attr);
+        $this->assertEquals('funtimes', $tag->class['value']);
+        $this->assertEquals('https://www.google.com', $tag->href['value']);
+    }
+
     public function testNoise()
     {
         $tag = new Tag('a');


### PR DESCRIPTION
This PR should fix #100 and I'll continue looking into issue #99 as well to see if I can fix that too.

I found the issue while working with this library to create a tool I need for work. I wasn't getting the expected output from the outerHtml() function after updating link href's so I needed to dig deeper. After investigating the issue and finding issue #99 I realized they are very similar and related to the same underlying bugs.