### PR TITLE
libraries that use composer should have a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.phar
+composer.lock
+/vendor/


### PR DESCRIPTION
All composer based/distributed libraries should include a local gitignore to prevent the vendor folder from being included. 

I've included what I would call the default minimum; I was considering leaving composer.lock off the list, but as it's not currently synced it should be included here.