### PR TITLE
added optional array of tags to exempt from trailing slashes for self…

### DIFF
--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -91,6 +91,13 @@ class Dom
     ];
 
     /**
+     * A list of tags where there should be no /> at the end (html5 style)
+     *
+     * @var array
+     */
+    protected $noSlash = [];
+
+    /**
      * Returns the inner html of the root node.
      *
      * @return string
@@ -263,6 +270,53 @@ class Dom
     public function clearSelfClosingTags()
     {
         $this->selfClosing = [];
+
+        return $this;
+    }
+
+
+    /**
+     * Adds a tag to the list of self closing tags that should not have a trailing slash
+     *
+     * @param $tag
+     * @return $this
+     */
+    public function addNoSlashTag($tag)
+    {
+        if ( ! is_array($tag)) {
+            $tag = [$tag];
+        }
+        foreach ($tag as $value) {
+            $this->noSlash[] = $value;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Removes a tag from the list of no-slash tags.
+     *
+     * @param $tag
+     * @return $this
+     */
+    public function removeNoSlashTag($tag)
+    {
+        if ( ! is_array($tag)) {
+            $tag = [$tag];
+        }
+        $this->noSlash = array_diff($this->noSlash, $tag);
+
+        return $this;
+    }
+
+    /**
+     * Empties the list of no-slash tags.
+     *
+     * @return $this
+     */
+    public function clearNoSlashTags()
+    {
+        $this->noSlash = [];
 
         return $this;
     }
@@ -588,6 +642,13 @@ class Dom
 
             // We force self closing on this tag.
             $node->getTag()->selfClosing();
+
+            // Should this tag use a trailing slash?
+            if(in_array($tag, $this->noSlash))
+            {
+                $node->getTag()->noTrailingSlash();
+            }
+
         }
 
         $this->content->fastForward(1);

--- a/src/PHPHtmlParser/Dom/Tag.php
+++ b/src/PHPHtmlParser/Dom/Tag.php
@@ -34,6 +34,13 @@ class Tag
     protected $selfClosing = false;
 
     /**
+     * If self-closing, will this use a trailing slash. />
+     *
+     * @var bool
+     */
+    protected $trailingSlash = true;
+
+    /**
      * Tag noise
      */
     protected $noise = '';
@@ -95,6 +102,19 @@ class Tag
     public function selfClosing()
     {
         $this->selfClosing = true;
+
+        return $this;
+    }
+
+
+    /**
+     * Sets the tag to not use a trailing slash.
+     *
+     * @return $this
+     */
+    public function noTrailingSlash()
+    {
+        $this->trailingSlash = false;
 
         return $this;
     }
@@ -247,7 +267,7 @@ class Tag
             }
         }
 
-        if ($this->selfClosing) {
+        if ($this->selfClosing && $this->trailingSlash) {
             return $return.' />';
         } else {
             return $return.'>';

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -88,6 +88,15 @@ class DomTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('<br /><p>Hey bro, <a href="google.com" data-quote="\"">click here</a></p>', $dom->find('div', 0)->innerHtml);
     }
 
+    public function testLoadClosingTagOnSelfClosingNoSlash()
+    {
+        $dom = new Dom;
+        $dom->addNoSlashTag("br");
+
+        $dom->load('<div class="all"><br><p>Hey bro, <a href="google.com" data-quote="\"">click here</a></br></div>');
+        $this->assertEquals('<br><p>Hey bro, <a href="google.com" data-quote="\"">click here</a></p>', $dom->find('div', 0)->innerHtml);
+    }
+
     public function testLoadClosingTagAddSelfClosingTag()
     {
         $dom = new Dom;


### PR DESCRIPTION
…-closing tags

Added an, empty by default, 'noSlash' array property with getters and setters, like the selfClosing array has, on the main Dom class. 
When a tag is in this array the trailing slash is not added to the tag in the Dom\Tag class, for HTML5-style tags rather than the xhtml version, which remains the default.
Added a single, simple test for this based on a previous test.