### PR TITLE
Resolves Problem with PHP 7.2 Throwing Error on count

### DIFF
--- a/src/PHPHtmlParser/Selector.php
+++ b/src/PHPHtmlParser/Selector.php
@@ -6,6 +6,7 @@ use PHPHtmlParser\Dom\Collection;
 use PHPHtmlParser\Dom\InnerNode;
 use PHPHtmlParser\Dom\LeafNode;
 use PHPHtmlParser\Exceptions\ChildNotFoundException;
+use Countable;
 
 /**
  * Class Selector
@@ -168,7 +169,9 @@ class Selector
     protected function seek(array $nodes, array $rule, array $options)
     {
         // XPath index
-        if (count($rule['tag']) > 0 &&
+        if ($rule['tag'] instanceof Countable && 
+            count($rule['tag']) > 0 &&
+            $rule['key'] instanceof Countable &&
             count($rule['key']) > 0 &&
             is_numeric($rule['key'])
         ) {


### PR DESCRIPTION
Problem: Currently PHP 7.2 throws an error if count is used on a non-countable object.
Resolution: Check for variable Countableness.
Change: Check variable is an instanceof Countable.