### PR TITLE
fix error: count(): Parameter must be an array or an object that implements Countable when use php 7.2

### DIFF
--- a/src/PHPHtmlParser/Selector.php
+++ b/src/PHPHtmlParser/Selector.php
@@ -168,7 +168,9 @@ class Selector
     protected function seek(array $nodes, array $rule, array $options)
     {
         // XPath index
-        if (count($rule['tag']) > 0 &&
+        if (is_array($rule['tag']) &&
+            is_array($rule['key']) &&
+            count($rule['tag']) > 0 &&
             count($rule['key']) > 0 &&
             is_numeric($rule['key'])
         ) {

--- a/src/PHPHtmlParser/Selector.php
+++ b/src/PHPHtmlParser/Selector.php
@@ -168,11 +168,8 @@ class Selector
     protected function seek(array $nodes, array $rule, array $options)
     {
         // XPath index
-        if (is_array($rule['tag']) &&
-            is_array($rule['key']) &&
-            count($rule['tag']) > 0 &&
-            count($rule['key']) > 0 &&
-            is_numeric($rule['key'])
+        if (strlen($rule['tag']) > 0 &&
+            (int) $rule['key'] > 0
         ) {
             $count = 0;
             /** @var AbstractNode $node */

--- a/tests/SelectorTest.php
+++ b/tests/SelectorTest.php
@@ -203,4 +203,18 @@ class SelectorTest extends PHPUnit_Framework_TestCase {
         $selector = new Selector('div > ul');
         $this->assertEquals(1, count($selector->find($root)));
     }
+
+    public function testFindNth()
+    {
+        $root   = new HtmlNode('root');
+        $parent = new HtmlNode('div');
+        $child1 = new HtmlNode('a');
+        $child2 = new HtmlNode('p');
+        $parent->addChild($child1);
+        $parent->addChild($child2);
+        $root->addChild($parent);
+
+        $selector = new Selector('div a');
+        $this->assertEquals($child1->id(), $selector->find($root, 1)->id());
+    }
 }


### PR DESCRIPTION
Hi

In php 7.2, can not use count() function for string, null , .... 
and now parser have error: count(): Parameter must be an array or an object that implements Countable
at file: php-html-parser/src/PHPHtmlParser/Selector.php line 171

I just fix it.