### PR TITLE
Improved PHPDoc comments for better class prediction in IDEs

### DIFF
--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -210,7 +210,7 @@ class Dom
      *
      * @param string $selector
      * @param int $nth
-     * @return array
+     * @return \PHPHtmlParser\Dom\AbstractNode[]|\PHPHtmlParser\Dom\AbstractNode
      */
     public function find($selector, $nth = null)
     {

--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -359,7 +359,7 @@ abstract class AbstractNode
      *
      * @param string $selector
      * @param int $nth
-     * @return array|AbstractNode
+     * @return AbstractNode[]|AbstractNode
      */
     public function find($selector, $nth = null)
     {


### PR DESCRIPTION
Added the proper classes as return type in the PHPDoc return type. This way IDEs are able to automatically detect the class of the return value and offer proper autocompletion.