### PR TITLE
Update CurlInterface.php

### DIFF
--- a/src/PHPHtmlParser/CurlInterface.php
+++ b/src/PHPHtmlParser/CurlInterface.php
@@ -15,5 +15,5 @@ interface CurlInterface
      * @param string $url
      * @return string
      */
-    public function get($url): string;
+    public function get(string $url): string;
 }


### PR DESCRIPTION
Fix PHPHtmlParser\CurlInterface::get() compatible issue

Getting the following error:

```
Fatal error: Declaration of PHPHtmlParser\Curl::get(string $url): string must be compatible with PHPHtmlParser\CurlInterface::get($url): string in /home/vagrant/code/vendor/paquettg/php-html-parser/src/PHPHtmlParser/Curl.php on line 11
```

When using this example:

```
use PHPHtmlParser\Dom;

$dom = new Dom;
$dom->loadFromUrl('http://google.com');
```