### PR TITLE
Fixing "typo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Preserves Line Breaks if set to `true`. If set to `false` line breaks are cleane
 **removeDoubleSpace**
 
 Set this to `false` if you want to preserver whitespace inside of text nodes. It is set to `true` by default.
+
 Static Facade
 -------------
 


### PR DESCRIPTION
Fixing typo at line 174, which had affect that description of removeDoubleSpace was interpreted as title