### PR TITLE
Add custom headers to curl request

### DIFF
--- a/src/PHPHtmlParser/Curl.php
+++ b/src/PHPHtmlParser/Curl.php
@@ -15,15 +15,20 @@ class Curl implements CurlInterface
      * A simple curl implementation to get the content of the url.
      *
      * @param string $url
+     * @param array $options
      * @return string
      * @throws CurlException
      */
-    public function get(string $url): string
+    public function get(string $url, array $options): string
     {
         $ch = curl_init($url);
 
         if ( ! ini_get('open_basedir')) {
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        }
+
+        if (isset($options['curlHeaders'])) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $options['curlHeaders']);
         }
 
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/src/PHPHtmlParser/CurlInterface.php
+++ b/src/PHPHtmlParser/CurlInterface.php
@@ -13,7 +13,8 @@ interface CurlInterface
      * This method should return the content of the url in a string
      *
      * @param string $url
+     * @param array $options
      * @return string
      */
-    public function get(string $url): string;
+    public function get(string $url, array $options): string;
 }

--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -191,7 +191,7 @@ class Dom
             // use the default curl interface
             $curl = new Curl;
         }
-        $content = $curl->get($url);
+        $content = $curl->get($url, $options);
 
         return $this->loadStr($content, $options);
     }


### PR DESCRIPTION
## Add custom headers to curl request
- pass headers as an option when using loadFromUrl

```php
$dom->loadFromUrl($url, [
    'curlHeaders' => ['Accept-Language: en-US,en;q=0.5;']
]);
```