### PR TITLE
Add method to return options as array

### DIFF
--- a/src/PHPHtmlParser/Options.php
+++ b/src/PHPHtmlParser/Options.php
@@ -97,4 +97,13 @@ class Options
 
         return null;
     }
+
+    /**
+     * Return current options as array
+     *
+     * @return array
+     */
+    public function asArray() {
+        return $this->options;
+    }
 }


### PR DESCRIPTION
Add method to return current options as array. This allows to use Options object to set options up, and then use it to set options in Dom, like this:

```
$options = new Options();
$options->setOptions(["strict" => true]);
        
$dom = new Dom();
$dom->setOptions($options->asArray());
```

I would maybe consider using Options object only for the future, or providing direct access to it on Dom object, instead of using array and setting up options later, in load method, but I believe that would be major breaking change unfortunately.