### PR TITLE
Add check for existence of an option

### DIFF
--- a/src/PHPHtmlParser/Exceptions/UnknownOptionException.php
+++ b/src/PHPHtmlParser/Exceptions/UnknownOptionException.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace PHPHtmlParser\Exceptions;
+
+use Exception;
+
+/**
+ * Class UnknownOptionException
+ *
+ * @package PHPHtmlParser\Exceptions
+ */
+final class UnknownOptionException extends Exception
+{
+}

--- a/src/PHPHtmlParser/Options.php
+++ b/src/PHPHtmlParser/Options.php
@@ -79,8 +79,8 @@ class Options
     public function setOptions(array $options): Options
     {
         foreach ($options as $key => $option) {
-            if (!isset($this->defaults[$key])) {
-                throw new UnknownOptionException("Option '$option' is not recognized");
+            if (!array_key_exists($key, $this->defaults)) {
+                throw new UnknownOptionException("Option '$key' is not recognized");
             }
             $this->options[$key] = $option;
         }

--- a/src/PHPHtmlParser/Options.php
+++ b/src/PHPHtmlParser/Options.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 namespace PHPHtmlParser;
 
+use PHPHtmlParser\Exceptions\UnknownOptionException;
+
 /**
  * Class Options
  *
@@ -72,10 +74,14 @@ class Options
      * @param array $options
      * @return Options
      * @chainable
+     * @throws UnknownOptionException
      */
     public function setOptions(array $options): Options
     {
         foreach ($options as $key => $option) {
+            if (!isset($this->defaults[$key])) {
+                throw new UnknownOptionException("Option '$option' is not recognized");
+            }
             $this->options[$key] = $option;
         }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use PHPHtmlParser\Dom;
+use PHPHtmlParser\Exceptions\UnknownOptionException;
 use PHPUnit\Framework\TestCase;
 use PHPHtmlParser\Options;
 
@@ -12,26 +14,37 @@ class OptionsTest extends TestCase {
         $this->assertTrue($options->whitespaceTextNode);
     }
 
+    public function testSettingOption()
+    {
+        $options = new Options;
+        $options->setOptions([
+            'strict' => true,
+        ]);
+
+        $this->assertTrue($options->strict);
+    }
+
     public function testAddingOption()
     {
+        $this->expectException(UnknownOptionException::class);
+
         $options = new Options;
         $options->setOptions([
             'test' => true,
         ]);
-
-        $this->assertTrue($options->test);
     }
 
-    public function testAddingOver()
+    public function testOverwritingOption()
     {
         $options = new Options;
         $options->setOptions([
-            'test' => false,
+            'strict' => false,
         ])->setOptions([
-            'test' => true,
+            'strict' => true,
             'whitespaceTextNode' => false,
         ]);
 
+        $this->assertTrue($options->get('strict'));
         $this->assertFalse($options->get('whitespaceTextNode'));
     }
 
@@ -39,6 +52,16 @@ class OptionsTest extends TestCase {
     {
         $options = new Options;
         $this->assertEquals(null, $options->get('doesnotexist'));
+    }
+
+    public function testUnknownOptionDom() {
+        $dom = new Dom;
+        $dom->setOptions([
+            'unknown_option' => true,
+        ]);
+
+        $this->expectException(UnknownOptionException::class);
+        $dom->load('<div></div>');
     }
 }
 


### PR DESCRIPTION
Add check for existence of an option, to prevent progammer's errors caused by typos.

I'm not sure whether there's a valid reason to set custom options, but if there is I would provide separate method.

As an example, this PR would prevent errors like this:
```
$dom->setOptions(['htmlSpecialCharDecode' => true]);
```
where there is a typo in "Char", which should be "Chars"