### PR TITLE
Add options setters

### DIFF
--- a/src/PHPHtmlParser/Options.php
+++ b/src/PHPHtmlParser/Options.php
@@ -55,6 +55,132 @@ class Options
     }
 
     /**
+     * The whitespaceTextNode, by default true, option tells the parser to save textnodes even if the content of the
+     * node is empty (only whitespace). Setting it to false will ignore all whitespace only text node found in the document.
+     * @param bool $value
+     * @return Options
+     */
+    public function setWhitespaceTextNode(bool $value): self {
+        $this->options['whitespaceTextNode'] = $value;
+        return $this;
+    }
+
+    /**
+     * Strict, by default false, will throw a StrictException if it finds that the html is not strictly compliant
+     * (all tags must have a closing tag, no attribute with out a value, etc.).
+     * @param bool $value
+     * @return Options
+     */
+    public function setStrict(bool $value): self {
+        $this->options['strict'] = $value;
+        return $this;
+    }
+
+    /**
+     * The enforceEncoding, by default null, option will enforce an character set to be used for reading the content
+     * and returning the content in that encoding. Setting it to null will trigger an attempt to figure out
+     * the encoding from within the content of the string given instead.
+     * @param string|null $value
+     * @return Options
+     */
+    public function setEnforceEncoding(?string $value): self {
+        $this->options['enforceEncoding'] = $value;
+        return $this;
+    }
+
+    /**
+     * Set this to false to skip the entire clean up phase of the parser. Defaults to true.
+     * @param bool $value
+     * @return Options
+     */
+    public function setCleanupInput(bool $value): self {
+        $this->options['cleanupInput'] = $value;
+        return $this;
+    }
+
+    /**
+     * Set this to false to skip removing the script tags from the document body. This might have adverse effects.
+     * Defaults to true.
+     *
+     * NOTE: Ignored if cleanupInit is true.
+     *
+     * @param bool $value
+     * @return Options
+     */
+    public function setRemoveScripts(bool $value): self {
+        $this->options['removeScripts'] = $value;
+        return $this;
+    }
+
+    /**
+     * Set this to false to skip removing of style tags from the document body. This might have adverse effects. Defaults to true.
+     *
+     * NOTE: Ignored if cleanupInit is true.
+     * @param bool $value
+     * @return Options
+     */
+    public function setRemoveStyles(bool $value): self {
+        $this->options['removeStyles'] = $value;
+        return $this;
+    }
+
+    /**
+     * Preserves Line Breaks if set to true. If set to false line breaks are cleaned up
+     * as part of the input clean up process. Defaults to false.
+     *
+     * NOTE: Ignored if cleanupInit is true.
+     * @param bool $value
+     * @return Options
+     */
+    public function setPreserveLineBreaks(bool $value): self {
+        $this->options['preserveLineBreaks'] = $value;
+        return $this;
+    }
+
+    /**
+     * Set this to false if you want to preserve whitespace inside of text nodes. It is set to true by default.
+     * @param bool $value
+     * @return Options
+     */
+    public function setRemoveDoubleSpace(bool $value): self {
+        $this->options['removeDoubleSpace'] = $value;
+        return $this;
+    }
+
+    /**
+     * Set this to false if you want to preserve smarty script found in the html content. It is set to true by default.
+     * @param bool $value
+     * @return Options
+     */
+    public function setRemoveSmartyScripts(bool $value): self {
+        $this->options['removeSmartyScripts'] = $value;
+        return $this;
+    }
+
+    /**
+     * By default this is set to false for legacy support. Setting this to true will change the behavior of find
+     * to order elements by depth first. This will properly preserve the order of elements as they where in the HTML.
+     *
+     * @param bool $value
+     * @return Options
+     * @deprecated This option will be removed in version 3.0.0 with the new behavior being as if it was set to true.
+     */
+    public function setDepthFirstSearch(bool $value): self {
+        $this->options['depthFirstSearch'] = $value;
+        return $this;
+    }
+
+    /**
+     * By default this is set to false. Setting this to true will apply the php function htmlspecialchars_decode too all attribute values and text nodes.
+     * @param bool $value
+     * @return Options
+     */
+    public function setHtmlSpecialCharsDecode(bool $value): self {
+        $this->options['htmlSpecialCharsDecode'] = $value;
+        return $this;
+    }
+
+    /**
      * A magic get to call the get() method.
      *
      * @param string $key

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -40,5 +40,91 @@ class OptionsTest extends TestCase {
         $options = new Options;
         $this->assertEquals(null, $options->get('doesnotexist'));
     }
+
+    public function testSetters() {
+        $options = new Options();
+
+        $options->setOptions([
+            'whitespaceTextNode'     => false,
+            'strict'                 => false,
+            'enforceEncoding'        => null,
+            'cleanupInput'           => false,
+            'removeScripts'          => false,
+            'removeStyles'           => false,
+            'preserveLineBreaks'     => false,
+            'removeDoubleSpace'      => false,
+            'removeSmartyScripts'    => false,
+            'depthFirstSearch'       => false,
+            'htmlSpecialCharsDecode' => false,
+        ]);
+
+        $options->setWhitespaceTextNode(true);
+        $this->assertTrue($options->get('whitespaceTextNode'));
+
+        $options->setStrict(true);
+        $this->assertTrue($options->get('strict'));
+
+        $options->setEnforceEncoding("utf8");
+        $this->assertEquals("utf8", $options->get('enforceEncoding'));
+
+        $options->setCleanupInput(true);
+        $this->assertTrue($options->get('cleanupInput'));
+
+        $options->setRemoveScripts(true);
+        $this->assertTrue($options->get('removeScripts'));
+
+        $options->setRemoveStyles(true);
+        $this->assertTrue($options->get('removeStyles'));
+
+        $options->setPreserveLineBreaks(true);
+        $this->assertTrue($options->get('preserveLineBreaks'));
+
+        $options->setRemoveDoubleSpace(true);
+        $this->assertTrue($options->get('removeDoubleSpace'));
+
+        $options->setRemoveSmartyScripts(true);
+        $this->assertTrue($options->get('removeSmartyScripts'));
+
+        $options->setDepthFirstSearch(true);
+        $this->assertTrue($options->get('depthFirstSearch'));
+
+        $options->setHtmlSpecialCharsDecode(true);
+        $this->assertTrue($options->get('htmlSpecialCharsDecode'));
+
+        // now reset to false
+
+        $options->setWhitespaceTextNode(false);
+        $this->assertFalse($options->get('whitespaceTextNode'));
+
+        $options->setStrict(false);
+        $this->assertFalse($options->get('strict'));
+
+        $options->setEnforceEncoding(null);
+        $this->assertNull($options->get('enforceEncoding'));
+
+        $options->setCleanupInput(false);
+        $this->assertFalse($options->get('cleanupInput'));
+
+        $options->setRemoveScripts(false);
+        $this->assertFalse($options->get('removeScripts'));
+
+        $options->setRemoveStyles(false);
+        $this->assertFalse($options->get('removeStyles'));
+
+        $options->setPreserveLineBreaks(false);
+        $this->assertFalse($options->get('preserveLineBreaks'));
+
+        $options->setRemoveDoubleSpace(false);
+        $this->assertFalse($options->get('removeDoubleSpace'));
+
+        $options->setRemoveSmartyScripts(false);
+        $this->assertFalse($options->get('removeSmartyScripts'));
+
+        $options->setDepthFirstSearch(false);
+        $this->assertFalse($options->get('depthFirstSearch'));
+
+        $options->setHtmlSpecialCharsDecode(false);
+        $this->assertFalse($options->get('htmlSpecialCharsDecode'));
+    }
 }
 


### PR DESCRIPTION
Add proper setters for options. This will help in IDEs to hint available options, instead of relying on docs, as well as ensure types and provides better documentation - e.g. allows to use @deprecated tag with more info, in this case for `depthFirstSearch` options.

Due to this change I would suggest to stop using array in Dom to set up options and instead work on Options object.