### PR TITLE
Optimize find

### DIFF
--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -269,6 +269,21 @@ class Dom
     }
 
     /**
+     * Get nth element by css selector on the root node.
+     * @param string   $selector
+     * @param int|null $nth
+     * @return AbstractNode|null
+     * @throws ChildNotFoundException
+     * @throws NotLoadedException
+     */
+    public function get(string $selector, int $nth = 0)
+    {
+        $this->isLoaded();
+
+        return $this->root->get($selector, $nth);
+    }
+
+    /**
      * Find element by Id on the root node
      * @param int $id
      * @return bool|AbstractNode

--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -453,18 +453,21 @@ abstract class AbstractNode
     {
         $selector = new Selector($selector, new SelectorParser());
         $selector->setDepthFirstFind($depthFirst);
-        $nodes    = $selector->find($this);
 
-        if ( ! is_null($nth)) {
-            // return nth-element or array
-            if (isset($nodes[$nth])) {
-                return $nodes[$nth];
+        if (is_null($nth)) {
+            return $selector->find($this);
+        } else {
+            $nodes = $selector->findGenerator($this);
+            for ($i=0; $i<$nth-1; $i++) {
+                if (!$nodes->valid()) { break; }
+                $nodes->next();
+            }
+            if ($nodes->valid()) {
+                return $nodes->current();
             }
 
             return null;
         }
-
-        return $nodes;
     }
 
     /**

--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -452,7 +452,7 @@ abstract class AbstractNode
     public function find(string $selector, int $nth = null, bool $depthFirst = false)
     {
         if (is_null($nth)) {
-            $selector = new Selector($selector, new SelectorParser());
+            $selector = new Selector($selector, SelectorParser::getInstance());
             $selector->setDepthFirstFind($depthFirst);
             return $selector->find($this);
         } else {
@@ -469,7 +469,7 @@ abstract class AbstractNode
      */
     public function get(string $selector, int $nth=0)
     {
-        $selector = new Selector($selector, new SelectorParser());
+        $selector = new Selector($selector, SelectorParser::getInstance());
         $selector->setDepthFirstFind(true);
 
         $nodes = $selector->findGenerator($this);

--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -451,23 +451,37 @@ abstract class AbstractNode
      */
     public function find(string $selector, int $nth = null, bool $depthFirst = false)
     {
-        $selector = new Selector($selector, new SelectorParser());
-        $selector->setDepthFirstFind($depthFirst);
-
         if (is_null($nth)) {
+            $selector = new Selector($selector, new SelectorParser());
+            $selector->setDepthFirstFind($depthFirst);
             return $selector->find($this);
         } else {
-            $nodes = $selector->findGenerator($this);
-            for ($i=0; $i<$nth-1; $i++) {
-                if (!$nodes->valid()) { break; }
-                $nodes->next();
-            }
-            if ($nodes->valid()) {
-                return $nodes->current();
-            }
-
-            return null;
+            return $this->get($selector, $nth);
         }
+    }
+
+    /**
+     * Get nth element by css selector
+     * @param string   $selector
+     * @param int|null $nth
+     * @return AbstractNode|null
+     * @throws ChildNotFoundException
+     */
+    public function get(string $selector, int $nth=0)
+    {
+        $selector = new Selector($selector, new SelectorParser());
+        $selector->setDepthFirstFind(true);
+
+        $nodes = $selector->findGenerator($this);
+        for ($i=0; $i<$nth-1; $i++) {
+            if (!$nodes->valid()) { break; }
+            $nodes->next();
+        }
+        if ($nodes->valid()) {
+            return $nodes->current();
+        }
+
+        return null;
     }
 
     /**

--- a/src/PHPHtmlParser/Selector/Parser.php
+++ b/src/PHPHtmlParser/Selector/Parser.php
@@ -12,6 +12,19 @@ namespace PHPHtmlParser\Selector;
 class Parser implements ParserInterface
 {
 
+    private static $instance = null;
+
+    public static function getInstance(): Parser {
+        if (is_null(self::$instance)) {
+            self::$instance = new Parser();
+        }
+        return self::$instance;
+    }
+
+    private function __construct() {
+        // use getInstance()
+    }
+
     /**
      * Pattern of CSS selectors, modified from 'mootools'
      *

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -21,7 +21,7 @@ class CollectionTest extends TestCase {
         $parent->addChild($child2);
         $child2->addChild($child3);
 
-        $selector   = new Selector('a', new Parser());
+        $selector   = new Selector('a', Parser::getInstance());
         $collection = $selector->find($root);
         $count      = 0;
         $collection->each(function ($node) use (&$count) {
@@ -58,7 +58,7 @@ class CollectionTest extends TestCase {
         $parent->addChild($child2);
         $child2->addChild($child3);
 
-        $selector = new Selector('div * a', new Parser());
+        $selector = new Selector('div * a', Parser::getInstance());
         $this->assertEquals($child3->id(), $selector->find($root)->id());
     }
 
@@ -74,7 +74,7 @@ class CollectionTest extends TestCase {
         $parent->addChild($child2);
         $child2->addChild($child3);
 
-        $selector = new Selector('div * a', new Parser());
+        $selector = new Selector('div * a', Parser::getInstance());
         $this->assertEquals($child3->innerHtml, $selector->find($root)->innerHtml);
     }
 
@@ -99,7 +99,7 @@ class CollectionTest extends TestCase {
         $parent->addChild($child2);
         $child2->addChild($child3);
 
-        $selector = new Selector('div * a', new Parser());
+        $selector = new Selector('div * a', Parser::getInstance());
         $this->assertEquals((string)$child3, (string)$selector->find($root));
     }
 
@@ -115,7 +115,7 @@ class CollectionTest extends TestCase {
         $parent->addChild($child2);
         $child2->addChild($child3);
 
-        $selector   = new Selector('a', new Parser());
+        $selector   = new Selector('a', Parser::getInstance());
         $collection = $selector->find($root);
         $array      = $collection->toArray();
         $lastA      = end($array);

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -529,4 +529,13 @@ class DomTest extends TestCase {
         $children = $dom->find('#red-line-g *');
         $this->assertEquals(25, count($children));
     }
+
+    public function testGet()
+    {
+        $dom = new Dom();
+        $dom->load('<div><a href="/test/"><img alt="\" src="/img/test.png" /><br /></a><a href="/demo/"><img alt="demo" src="/img/demo.png" /></a></div>');
+        $imgs = $dom->get('img');
+        $this->assertEquals("/img/test.png", $imgs->getAttribute('src'));
+    }
+
 }

--- a/tests/Selector/SelectorLargeDomTest.php
+++ b/tests/Selector/SelectorLargeDomTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+use PHPHtmlParser\Selector\Selector;
+use PHPUnit\Framework\TestCase;
+use PHPHtmlParser\Dom\HtmlNode;
+use PHPHtmlParser\Dom\Tag;
+
+class SelectorLargeDomTest extends TestCase {
+
+    const DivCount = 10000;
+
+    private static $parent;
+    private $time;
+
+    public static function setUpBeforeClass() {
+        parent::setUpBeforeClass();
+
+        $div = new Tag('div');
+        $parent = new HtmlNode($div);
+
+        for ($i=0; $i<self::DivCount; $i++) {
+            $div = new Tag('div');
+            $div->setAttribute("data-index", (string)$i);
+            $parent->addChild(new HtmlNode($div));
+        }
+
+        self::$parent = $parent;
+    }
+
+    public static function tearDownAfterClass() {
+        parent::tearDownAfterClass();
+        self::$parent = null;
+    }
+
+    protected function setUp() {
+        parent::setUp();
+        $this->time = microtime(true);
+    }
+
+    protected function tearDown() {
+        parent::tearDown();
+        // echo microtime(true) - $this->time."\n";
+    }
+
+    public function testGetAllDivs() {
+        $result = self::$parent->find("div");
+        $this->assertInstanceOf(\PHPHtmlParser\Dom\Collection::class, $result);
+        $this->assertEquals(self::DivCount, count($result));
+    }
+
+    public function testGetFirstDiv() {
+        $result = self::$parent->find("div", 0, true);
+        $this->assertInstanceOf(\PHPHtmlParser\Dom\AbstractNode::class, $result);
+        $this->assertEquals("0", $result->getAttribute("data-index"));
+    }
+
+    public function testGet10thDiv() {
+        $result = self::$parent->find("div", 10, true);
+        $this->assertInstanceOf(\PHPHtmlParser\Dom\AbstractNode::class, $result);
+        $this->assertEquals("9", $result->getAttribute("data-index"));
+    }
+}

--- a/tests/Selector/SelectorTest.php
+++ b/tests/Selector/SelectorTest.php
@@ -10,28 +10,28 @@ class SelectorTest extends TestCase {
     
     public function testParseSelectorStringId()
     {
-        $selector  = new Selector('#all', new Parser());
+        $selector  = new Selector('#all', Parser::getInstance());
         $selectors = $selector->getSelectors();
         $this->assertEquals('id', $selectors[0][0]['key']);
     }
 
     public function testParseSelectorStringClass()
     {
-        $selector  = new Selector('div.post', new Parser());
+        $selector  = new Selector('div.post', Parser::getInstance());
         $selectors = $selector->getSelectors();
         $this->assertEquals('class', $selectors[0][0]['key']);
     }
 
     public function testParseSelectorStringAttribute()
     {
-        $selector  = new Selector('div[visible=yes]', new Parser());
+        $selector  = new Selector('div[visible=yes]', Parser::getInstance());
         $selectors = $selector->getSelectors();
         $this->assertEquals('yes', $selectors[0][0]['value']);
     }
 
     public function testParseSelectorStringNoKey()
     {
-        $selector  = new Selector('div[!visible]', new Parser());
+        $selector  = new Selector('div[!visible]', Parser::getInstance());
         $selectors = $selector->getSelectors();
         $this->assertTrue($selectors[0][0]['noKey']);
     }
@@ -46,7 +46,7 @@ class SelectorTest extends TestCase {
         $parent->addChild($child2);
         $root->addChild($parent);
 
-        $selector = new Selector('div a', new Parser());
+        $selector = new Selector('div a', Parser::getInstance());
         $this->assertEquals($child1->id(), $selector->find($root)[0]->id());
     }
 
@@ -64,7 +64,7 @@ class SelectorTest extends TestCase {
         $parent->addChild($child1);
         $parent->addChild($child2);
 
-        $selector = new Selector('#content', new Parser());
+        $selector = new Selector('#content', Parser::getInstance());
         $this->assertEquals($child2->id(), $selector->find($parent)[0]->id());
     }
 
@@ -84,7 +84,7 @@ class SelectorTest extends TestCase {
         $parent->addChild($child2);
         $parent->addChild($child3);
 
-        $selector = new Selector('.link', new Parser());
+        $selector = new Selector('.link', Parser::getInstance());
         $this->assertEquals($child3->id(), $selector->find($parent)[0]->id());
     }
 
@@ -104,7 +104,7 @@ class SelectorTest extends TestCase {
         $parent->addChild($child2);
         $parent->addChild($child3);
 
-        $selector = new Selector('.outer', new Parser());
+        $selector = new Selector('.outer', Parser::getInstance());
         $this->assertEquals($child3->id(), $selector->find($parent)[0]->id());
     }
 
@@ -120,7 +120,7 @@ class SelectorTest extends TestCase {
         $parent->addChild($child2);
         $child2->addChild($child3);
 
-        $selector = new Selector('div * a', new Parser());
+        $selector = new Selector('div * a', Parser::getInstance());
         $this->assertEquals($child3->id(), $selector->find($root)[0]->id());
     }
 
@@ -136,7 +136,7 @@ class SelectorTest extends TestCase {
         $parent->addChild($child2);
         $child2->addChild($child3);
 
-        $selector = new Selector('a, p', new Parser());
+        $selector = new Selector('a, p', Parser::getInstance());
         $this->assertEquals(3, count($selector->find($root)));
     }
 
@@ -156,7 +156,7 @@ class SelectorTest extends TestCase {
         $parent->addChild($child2);
         $parent->addChild($child3);
 
-        $selector = new Selector('div[1]', new Parser());
+        $selector = new Selector('div[1]', Parser::getInstance());
         $this->assertEquals($parent->id(), $selector->find($parent)[0]->id());
     }
 
@@ -170,7 +170,7 @@ class SelectorTest extends TestCase {
         $parent->addChild($child1);
         $child1->addChild($child2);
 
-        $selector = new Selector('div li', new Parser());
+        $selector = new Selector('div li', Parser::getInstance());
         $this->assertEquals(1, count($selector->find($root)));
     }
 
@@ -186,7 +186,7 @@ class SelectorTest extends TestCase {
         $child2->addChild($child3);
         $parent->addChild($child2);
 
-        $selector = new Selector('div ul', new Parser());
+        $selector = new Selector('div ul', Parser::getInstance());
         $this->assertEquals(2, count($selector->find($root)));
     }
 
@@ -202,7 +202,7 @@ class SelectorTest extends TestCase {
         $child2->addChild($child3);
         $parent->addChild($child2);
 
-        $selector = new Selector('div > ul', new Parser());
+        $selector = new Selector('div > ul', Parser::getInstance());
         $this->assertEquals(1, count($selector->find($root)));
     }
 
@@ -213,7 +213,7 @@ class SelectorTest extends TestCase {
         $child1->setAttribute('custom-attr', null);
         $root->addChild($child1);
 
-        $selector = new Selector('[custom-attr]', new Parser());
+        $selector = new Selector('[custom-attr]', Parser::getInstance());
         $this->assertEquals(1, count($selector->find($root)));
     }
 
@@ -227,7 +227,7 @@ class SelectorTest extends TestCase {
         $root->addChild($child1);
         $root->addChild($child2);
 
-        $selector = new Selector('a.b.c', new Parser());
+        $selector = new Selector('a.b.c', Parser::getInstance());
         $this->assertEquals(1, count($selector->find($root)));
     }
 }


### PR DESCRIPTION
Right now find() is searching whole document, even when only first or nth result is needed.
This can be optimized by using generator and returning early.

Along with that, due to Collection having magic methods that would execute on first found node, I have added `get()` helper method, which could be used instead `find()` when only first node is requested.

Last optimization is making selector parser singleton. Right now `find()` on each node would create new instance unneccessarily