### PR TITLE
Add array access for attributes on AbstractNode

### DIFF
--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -19,7 +19,7 @@ use PHPHtmlParser\Finder;
  * @property Tag       $tag
  * @property InnerNode $parent
  */
-abstract class AbstractNode
+abstract class AbstractNode implements \ArrayAccess
 {
     /**
      * @var int
@@ -522,4 +522,24 @@ abstract class AbstractNode
 
         return false;
     }
-}
+
+    /**
+     * Array Access
+     */
+
+     public function offsetExists($offset): bool {
+         return $this->hasAttribute($offset);
+     }
+
+     public function offsetGet($offset): ?string {
+         return $this->getAttribute($offset);
+     }
+
+     public function offsetSet($offset, $value): AbstractNode {
+         return $this->setAttribute($offset, $value);
+     }
+
+     public function offsetUnset($offset): void {
+         $this->removeAttribute($offset);
+     }
+ }

--- a/tests/Node/HtmlTest.php
+++ b/tests/Node/HtmlTest.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types=1);
-require_once('tests/data/MockNode.php');
+require_once(__DIR__.'/../data/MockNode.php');
 
 use PHPUnit\Framework\TestCase;
 use PHPHtmlParser\Dom;
@@ -358,7 +358,7 @@ class NodeHtmlTest extends TestCase {
                 'doubleQuote' => true,
             ],
         ]);
-        
+
         $this->assertEquals('outerlink rounded', $node->getAttribute('class'));
     }
 
@@ -379,6 +379,25 @@ class NodeHtmlTest extends TestCase {
         $this->assertEquals('http://google.com', $node->href);
     }
 
+    public function testGetAttributeArrayAccess()
+    {
+        $node = new HtmlNode('a');
+        $this->assertNull($node['class']);
+
+        $node->getTag()->setAttributes([
+            'href' => [
+                'value'       => 'http://google.com',
+                'doubleQuote' => false,
+            ],
+            'class' => [
+                'value'       => 'outerlink rounded',
+                'doubleQuote' => true,
+            ],
+        ]);
+
+        $this->assertEquals('outerlink rounded', $node['class']);
+    }
+
     public function testGetAttributes()
     {
         $node = new HtmlNode('a');
@@ -396,11 +415,29 @@ class NodeHtmlTest extends TestCase {
         $this->assertEquals('outerlink rounded', $node->getAttributes()['class']);
     }
 
+    public function testAttributeExistsArrayAccess()
+    {
+        $node = new HtmlNode('a');
+        $this->assertFalse(isset($node['class']));
+
+        $node['class'] = "cls";
+        $this->assertTrue(isset($node['class']));
+    }
+
     public function testSetAttribute()
     {
         $node = new HtmlNode('a');
         $node->setAttribute('class', 'foo');
         $this->assertEquals('foo', $node->getAttribute('class'));
+    }
+
+    public function testSetAttributeArrayAccess()
+    {
+        $node = new HtmlNode('a');
+        $this->assertNull($node['class']);
+
+        $node['class'] = "foo";
+        $this->assertEquals('foo', $node['class']);
     }
 
     public function testRemoveAttribute()
@@ -409,6 +446,19 @@ class NodeHtmlTest extends TestCase {
         $node->setAttribute('class', 'foo');
         $node->removeAttribute('class');
         $this->assertnull($node->getAttribute('class'));
+    }
+
+
+    public function testRemoveAttributeArrayAccess()
+    {
+        $node = new HtmlNode('a');
+        $this->assertNull($node['class']);
+
+        $node['class'] = 'foo';
+        $this->assertEquals("foo", $node['class']);
+
+        unset($node['class']);
+        $this->assertNull($node['class']);
     }
 
     public function testRemoveAllAttributes()


### PR DESCRIPTION
Even though AbstractNode supports magic get to query attributes, that wouldn't work for e.g. data- attributes and one would need to use lengthy `getAttribute()`. This PR adds array access for AbstractNode so we could use `$node['data-attr']`.