### PR TITLE
performance improvements

### DIFF
--- a/src/PHPHtmlParser/Content.php
+++ b/src/PHPHtmlParser/Content.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 declare(strict_types=1);
 
@@ -76,16 +76,7 @@ class Content
      */
     public function char(?int $char = null): string
     {
-        $pos = $this->pos;
-        if ( ! is_null($char)) {
-            $pos = $char;
-        }
-
-        if ( ! isset($this->content[$pos])) {
-            return '';
-        }
-
-        return $this->content[$pos];
+        return $this->content[$char ?? $this->pos] ?? '';
     }
 
     /**
@@ -137,7 +128,7 @@ class Content
         if ($escape) {
             $position = $this->pos;
             $found    = false;
-            while ( ! $found) {
+            while (!$found) {
                 $position = strpos($this->content, $string, $position);
                 if ($position === false) {
                     // reached the end
@@ -163,7 +154,7 @@ class Content
             // could not find character, just return the remaining of the content
             $return    = substr($this->content, $this->pos, $this->size - $this->pos);
             if ($return === false) {
-                throw new LogicalException('Substr returned false with position '.$this->pos.'.');
+                throw new LogicalException('Substr returned false with position ' . $this->pos . '.');
             }
             $this->pos = $this->size;
 
@@ -177,7 +168,7 @@ class Content
 
         $return = substr($this->content, $this->pos, $position - $this->pos);
         if ($return === false) {
-            throw new LogicalException('Substr returned false with position '.$this->pos.'.');
+            throw new LogicalException('Substr returned false with position ' . $this->pos . '.');
         }
         // set the new position
         $this->pos = $position;
@@ -201,7 +192,7 @@ class Content
 
         $position = strcspn($foundString, $unless);
         if ($position == strlen($foundString)) {
-            return $string.$foundString;
+            return $string . $foundString;
         }
         // rewind changes and return nothing
         $this->pos = $lastPos;
@@ -241,7 +232,7 @@ class Content
         if ($copy) {
             $return = substr($this->content, $this->pos, $len);
             if ($return === false) {
-                throw new LogicalException('Substr returned false with position '.$this->pos.'.');
+                throw new LogicalException('Substr returned false with position ' . $this->pos . '.');
             }
         }
 

--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace PHPHtmlParser;
 
 use PHPHtmlParser\Dom\AbstractNode;
@@ -174,7 +177,7 @@ class Dom
     {
         $content = file_get_contents($file);
         if ($content === false) {
-            throw new LogicalException('file_get_contents failed and returned false when trying to read "'.$file.'".');
+            throw new LogicalException('file_get_contents failed and returned false when trying to read "' . $file . '".');
         }
         return $this->loadStr($content, $options);
     }
@@ -193,7 +196,7 @@ class Dom
      */
     public function loadFromUrl(string $url, array $options = [], CurlInterface $curl = null): Dom
     {
-        if (is_null($curl)) {
+        if ($curl === null) {
             // use the default curl interface
             $curl = new Curl;
         }
@@ -216,7 +219,7 @@ class Dom
     {
         $this->options = new Options;
         $this->options->setOptions($this->globalOptions)
-                      ->setOptions($option);
+            ->setOptions($option);
 
         $this->rawSize = strlen($str);
         $this->raw     = $str;
@@ -293,7 +296,7 @@ class Dom
      */
     public function addSelfClosingTag($tag): Dom
     {
-        if ( ! is_array($tag)) {
+        if (!is_array($tag)) {
             $tag = [$tag];
         }
         foreach ($tag as $value) {
@@ -313,7 +316,7 @@ class Dom
      */
     public function removeSelfClosingTag($tag): Dom
     {
-        if ( ! is_array($tag)) {
+        if (!is_array($tag)) {
             $tag = [$tag];
         }
         $this->selfClosing = array_diff($this->selfClosing, $tag);
@@ -344,7 +347,7 @@ class Dom
      */
     public function addNoSlashTag($tag): Dom
     {
-        if ( ! is_array($tag)) {
+        if (!is_array($tag)) {
             $tag = [$tag];
         }
         foreach ($tag as $value) {
@@ -363,7 +366,7 @@ class Dom
      */
     public function removeNoSlashTag($tag): Dom
     {
-        if ( ! is_array($tag)) {
+        if (!is_array($tag)) {
             $tag = [$tag];
         }
         $this->noSlash = array_diff($this->noSlash, $tag);
@@ -461,7 +464,7 @@ class Dom
     {
         $this->isLoaded();
 
-        return $this->find('#'.$id, 0);
+        return $this->find('#' . $id, 0);
     }
 
     /**
@@ -491,7 +494,7 @@ class Dom
     {
         $this->isLoaded();
 
-        return $this->find('.'.$class);
+        return $this->find('.' . $class);
     }
 
     /**
@@ -622,11 +625,11 @@ class Dom
         $this->root = new HtmlNode('root');
         $this->root->setHtmlSpecialCharsDecode($this->options->htmlSpecialCharsDecode);
         $activeNode = $this->root;
-        while ( ! is_null($activeNode)) {
+        while ($activeNode !== null) {
             $str = $this->content->copyUntil('<');
             if ($str == '') {
                 $info = $this->parseTag();
-                if ( ! $info['status']) {
+                if (!$info['status']) {
                     // we are done here
                     $activeNode = null;
                     continue;
@@ -638,7 +641,7 @@ class Dom
                     $originalNode     = $activeNode;
                     while ($activeNode->getTag()->name() != $info['tag']) {
                         $activeNode = $activeNode->getParent();
-                        if (is_null($activeNode)) {
+                        if ($activeNode === null) {
                             // we could not find opening tag
                             $activeNode = $originalNode;
                             $foundOpeningTag = false;
@@ -651,7 +654,7 @@ class Dom
                     continue;
                 }
 
-                if ( ! isset($info['node'])) {
+                if (!isset($info['node'])) {
                     continue;
                 }
 
@@ -660,10 +663,11 @@ class Dom
                 $activeNode->addChild($node);
 
                 // check if node is self closing
-                if ( ! $node->getTag()->isSelfClosing()) {
+                if (!$node->getTag()->isSelfClosing()) {
                     $activeNode = $node;
                 }
-            } else if ($this->options->whitespaceTextNode ||
+            } elseif (
+                $this->options->whitespaceTextNode ||
                 trim($str) != ''
             ) {
                 // we found text we care about
@@ -696,7 +700,7 @@ class Dom
         if ($this->content->fastForward(1)->char() == '/') {
             // end tag
             $tag = $this->content->fastForward(1)
-                                 ->copyByToken('slash', true);
+                ->copyByToken('slash', true);
             // move to end of tag
             $this->content->copyUntil('>');
             $this->content->fastForward(1);
@@ -717,8 +721,7 @@ class Dom
         }
 
         $tag  = strtolower($this->content->copyByToken('slash', true));
-        if (trim($tag) == '')
-        {
+        if (trim($tag) == '') {
             // no tag found, invalid < found
             return $return;
         }
@@ -726,8 +729,10 @@ class Dom
         $node->setHtmlSpecialCharsDecode($this->options->htmlSpecialCharsDecode);
 
         // attributes
-        while ($this->content->char() != '>' &&
-            $this->content->char() != '/') {
+        while (
+            $this->content->char() != '>' &&
+            $this->content->char() != '/'
+        ) {
             $space = $this->content->skipByToken('blank', true);
             if (empty($space)) {
                 $this->content->fastForward(1);
@@ -740,15 +745,15 @@ class Dom
             }
 
             if (empty($name)) {
-				$this->content->skipByToken('blank');
-				continue;
+                $this->content->skipByToken('blank');
+                continue;
             }
 
             $this->content->skipByToken('blank');
             if ($this->content->char() == '=') {
                 $attr = [];
                 $this->content->fastForward(1)
-                              ->skipByToken('blank');
+                    ->skipByToken('blank');
                 switch ($this->content->char()) {
                     case '"':
                         $attr['doubleQuote'] = true;
@@ -757,7 +762,7 @@ class Dom
                         do {
                             $moreString = $this->content->copyUntilUnless('"', '=>');
                             $string .= $moreString;
-                        } while ( ! empty($moreString));
+                        } while (!empty($moreString));
                         $attr['value'] = $string;
                         $this->content->fastForward(1);
                         $node->getTag()->$name = $attr;
@@ -769,7 +774,7 @@ class Dom
                         do {
                             $moreString = $this->content->copyUntilUnless("'", '=>');
                             $string .= $moreString;
-                        } while ( ! empty($moreString));
+                        } while (!empty($moreString));
                         $attr['value'] = $string;
                         $this->content->fastForward(1);
                         $node->getTag()->$name = $attr;
@@ -815,11 +820,9 @@ class Dom
             $node->getTag()->selfClosing();
 
             // Should this tag use a trailing slash?
-            if(in_array($tag, $this->noSlash, true))
-            {
+            if (in_array($tag, $this->noSlash, true)) {
                 $node->getTag()->noTrailingSlash();
             }
-
         }
 
         $this->content->fastForward(1);
@@ -844,7 +847,7 @@ class Dom
         $encode->to($this->defaultCharset);
 
         $enforceEncoding = $this->options->enforceEncoding;
-        if ( ! is_null($enforceEncoding)) {
+        if (!is_null($enforceEncoding)) {
             //  they want to enforce the given encoding
             $encode->from($enforceEncoding);
             $encode->to($enforceEncoding);

--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace PHPHtmlParser\Dom;
 
 use PHPHtmlParser\Exceptions\CircularException;
@@ -91,7 +94,7 @@ abstract class AbstractNode
     public function __get(string $key)
     {
         // check attribute first
-        if ( ! is_null($this->getAttribute($key))) {
+        if ($this->getAttribute($key) !== null) {
             return $this->getAttribute($key);
         }
         switch (strtolower($key)) {
@@ -181,7 +184,7 @@ abstract class AbstractNode
     public function setParent(InnerNode $parent): AbstractNode
     {
         // remove from old parent
-        if ( ! is_null($this->parent)) {
+        if ($this->parent !== null) {
             if ($this->parent->id() == $parent->id()) {
                 // already the parent
                 return $this;
@@ -206,7 +209,7 @@ abstract class AbstractNode
      */
     public function delete()
     {
-        if ( ! is_null($this->parent)) {
+        if ($this->parent !== null) {
             $this->parent->removeChild($this->id);
         }
         $this->parent->clear();
@@ -232,9 +235,9 @@ abstract class AbstractNode
      * @param int $id
      * @return bool
      */
-    public function isAncestor(int $id): Bool
+    public function isAncestor(int $id): bool
     {
-        if ( ! is_null($this->getAncestor($id))) {
+        if ($this->getAncestor($id) !== null) {
             return true;
         }
 
@@ -249,14 +252,9 @@ abstract class AbstractNode
      */
     public function getAncestor(int $id)
     {
-        if ( ! is_null($this->parent)) {
-            if ($this->parent->id() == $id) {
-                return $this->parent;
-            }
-
-            return $this->parent->getAncestor($id);
+        if ($this->parent !== null && $this->parent->id() == $id) {
+            return $this->parent;
         }
-
         return null;
     }
 
@@ -267,21 +265,16 @@ abstract class AbstractNode
      */
     public function hasNextSibling(): bool
     {
-        try
-        {
+        try {
             $this->nextSibling();
 
             // sibling found, return true;
             return true;
-        }
-        catch (ParentNotFoundException $e)
-        {
+        } catch (ParentNotFoundException $e) {
             // no parent, no next sibling
             unset($e);
             return false;
-        }
-        catch (ChildNotFoundException $e)
-        {
+        } catch (ChildNotFoundException $e) {
             // no sibling found
             unset($e);
             return false;
@@ -296,7 +289,7 @@ abstract class AbstractNode
      */
     public function nextSibling(): AbstractNode
     {
-        if (is_null($this->parent)) {
+        if ($this->parent === null) {
             throw new ParentNotFoundException('Parent is not set for this node.');
         }
 
@@ -311,7 +304,7 @@ abstract class AbstractNode
      */
     public function previousSibling(): AbstractNode
     {
-        if (is_null($this->parent)) {
+        if ($this->parent === null) {
             throw new ParentNotFoundException('Parent is not set for this node.');
         }
 
@@ -430,15 +423,15 @@ abstract class AbstractNode
         // Start by including ourselves in the comparison.
         $node = $this;
 
-        while ( ! is_null($node)) {
+        do {
             if ($node->tag->name() == $tag) {
                 return $node;
             }
 
             $node = $node->getParent();
-        }
+        } while ($node !== null);
 
-        throw new ParentNotFoundException('Could not find an ancestor with "'.$tag.'" tag');
+        throw new ParentNotFoundException('Could not find an ancestor with "' . $tag . '" tag');
     }
 
     /**
@@ -449,13 +442,13 @@ abstract class AbstractNode
      * @return mixed|Collection|null
      * @throws ChildNotFoundException
      */
-    public function find(string $selector, int $nth = null, bool $depthFirst = false)
+    public function find(string $selector, ?int $nth = null, bool $depthFirst = false)
     {
         $selector = new Selector($selector, new SelectorParser());
         $selector->setDepthFirstFind($depthFirst);
         $nodes    = $selector->find($this);
 
-        if ( ! is_null($nth)) {
+        if ($nth !== null) {
             // return nth-element or array
             if (isset($nodes[$nth])) {
                 return $nodes[$nth];
@@ -476,7 +469,7 @@ abstract class AbstractNode
      */
     public function findById(int $id)
     {
-        $finder= new Finder($id);
+        $finder = new Finder($id);
 
         return $finder->find($this);
     }
@@ -517,7 +510,7 @@ abstract class AbstractNode
      *
      * @return boolean
      */
-    public function isTextNode(): bool 
+    public function isTextNode(): bool
     {
 
         return false;

--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -252,8 +252,11 @@ abstract class AbstractNode
      */
     public function getAncestor(int $id)
     {
-        if ($this->parent !== null && $this->parent->id() == $id) {
-            return $this->parent;
+        if ($this->parent !== null) {
+            if ($this->parent->id() == $id) {
+                return $this->parent;
+            }
+            return $this->parent->getAncestor($id);
         }
         return null;
     }

--- a/src/PHPHtmlParser/Dom/HtmlNode.php
+++ b/src/PHPHtmlParser/Dom/HtmlNode.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace PHPHtmlParser\Dom;
 
 use PHPHtmlParser\Exceptions\UnknownChildTypeException;
@@ -48,7 +51,7 @@ class HtmlNode extends InnerNode
      */
     public function __construct($tag)
     {
-        if ( ! $tag instanceof Tag) {
+        if (!$tag instanceof Tag) {
             $tag = new Tag($tag);
         }
         $this->tag = $tag;
@@ -73,12 +76,12 @@ class HtmlNode extends InnerNode
      */
     public function innerHtml(): string
     {
-        if ( ! $this->hasChildren()) {
+        if (!$this->hasChildren()) {
             // no children
             return '';
         }
 
-        if ( ! is_null($this->innerHtml)) {
+        if ($this->innerHtml !== null) {
             // we already know the result.
             return $this->innerHtml;
         }
@@ -87,13 +90,13 @@ class HtmlNode extends InnerNode
         $string = '';
 
         // continue to loop until we are out of children
-        while ( ! is_null($child)) {
+        while ($child !== null) {
             if ($child instanceof TextNode) {
                 $string .= $child->text();
             } elseif ($child instanceof HtmlNode) {
                 $string .= $child->outerHtml();
             } else {
-                throw new UnknownChildTypeException('Unknown child type "'.get_class($child).'" found in node');
+                throw new UnknownChildTypeException('Unknown child type "' . get_class($child) . '" found in node');
             }
 
             try {
@@ -125,7 +128,7 @@ class HtmlNode extends InnerNode
             return $this->innerHtml();
         }
 
-        if ( ! is_null($this->outerHtml)) {
+        if ($this->outerHtml !== null) {
             // we already know the results.
             return $this->outerHtml;
         }
@@ -158,11 +161,11 @@ class HtmlNode extends InnerNode
     public function text(bool $lookInChildren = false): string
     {
         if ($lookInChildren) {
-            if ( ! is_null($this->textWithChildren)) {
+            if ($this->textWithChildren !== null) {
                 // we already know the results.
                 return $this->textWithChildren;
             }
-        } elseif ( ! is_null($this->text)) {
+        } elseif ($this->text !== null) {
             // we already know the results.
             return $this->text;
         }
@@ -174,7 +177,8 @@ class HtmlNode extends InnerNode
             $node = $child['node'];
             if ($node instanceof TextNode) {
                 $text .= $child['node']->text;
-            } elseif ($lookInChildren &&
+            } elseif (
+                $lookInChildren &&
                 $node instanceof HtmlNode
             ) {
                 $text .= $node->text($lookInChildren);
@@ -202,7 +206,7 @@ class HtmlNode extends InnerNode
         $this->text      = null;
         $this->textWithChildren = null;
 
-        if (!is_null($this->parent)) {
+        if ($this->parent !== null) {
             $this->parent->clear();
         }
     }

--- a/src/PHPHtmlParser/Dom/InnerNode.php
+++ b/src/PHPHtmlParser/Dom/InnerNode.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 declare(strict_types=1);
 

--- a/tests/Node/ParentTest.php
+++ b/tests/Node/ParentTest.php
@@ -301,6 +301,7 @@ class NodeParentTest extends TestCase {
         $parent->addChild($child);
         $child->addChild($child2);
         $ancestor = $child2->getAncestor($parent->id());
+        $this->assertNotNull($ancestor);
         $this->assertEquals($parent->id(), $ancestor->id());
     }
 


### PR DESCRIPTION
Hi,

I've ran into performance issues with php-html-parser, managed to reduce parsing time a lot (seen 10% improvements on big files). Mainly changed `is_null` to `=== null`, this removes the need for function-call-overhead. Also rewritten `Content::char()` to use NULL-coalescing operator which is faster than 2 function-calls as this function is called quite often.

A lot of indent-changes are free, my editor formats on save and is set to PSR-12. Since CONTRIBUTING.md states PSR-12 I don't think that is a problem.

Kind regards,

Rik