### PR TITLE
CDATA should not be altered when cleanupInput is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added PHAN support and fixed all issues from PHAN.
+
 ### Changed
 - Fixed issue with \ causing an infite loop.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PHP Html Parser
 ==========================
 
-Version 2.2.0
+Version 2.2.1
 
 [![Build Status](https://travis-ci.org/paquettg/php-html-parser.png)](https://travis-ci.org/paquettg/php-html-parser)
 [![Coverage Status](https://coveralls.io/repos/paquettg/php-html-parser/badge.png)](https://coveralls.io/r/paquettg/php-html-parser)

--- a/src/PHPHtmlParser/Dom.php
+++ b/src/PHPHtmlParser/Dom.php
@@ -623,7 +623,13 @@ class Dom
         $this->root->setHtmlSpecialCharsDecode($this->options->htmlSpecialCharsDecode);
         $activeNode = $this->root;
         while ( ! is_null($activeNode)) {
-            $str = $this->content->copyUntil('<');
+            if ($activeNode && $activeNode->tag->name() === 'script'
+                && $this->options->get('cleanupInput') != true
+            ) {
+                $str = $this->content->copyUntil('</');
+            } else {
+                $str = $this->content->copyUntil('<');
+            }
             if ($str == '') {
                 $info = $this->parseTag();
                 if ( ! $info['status']) {

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -12,6 +12,18 @@ class DomTest extends TestCase {
         Mockery::close();
     }
 
+    /**
+     * <![CDATA[ should not be modified when cleanupInput is set to false
+     */
+    public function testParsingCData()
+    {
+        $html = "<script type=\"text/javascript\">/* <![CDATA[ */var et_core_api_spam_recaptcha = '';/* ]]> */</script>";
+        $dom = new Dom();
+        $dom->setOptions(['cleanupInput' => false,]);
+        $dom->load($html);
+        $this->assertSame($html, $dom->root->outerHtml());
+    }
+
     public function testLoad()
     {
         $dom = new Dom;


### PR DESCRIPTION
This library breaks Javascript like:
    `<script type="text/javascript">/* <![CDATA[ */var a = 'hello'; /* ]]> */</script>`
because it is modifying the CDATA part, turning the above to:
    `<script type="text/javascript">/* <![cdata[ * />var a = 'hello'; /* ]]> */</script>`

This PR attempts to fix the above issue
