### PR TITLE
feature: innerText property support

### DIFF
--- a/src/PHPHtmlParser/Dom/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/AbstractNode.php
@@ -99,6 +99,8 @@ abstract class AbstractNode
                 return $this->outerHtml();
             case 'innerhtml':
                 return $this->innerHtml();
+            case 'innertext':
+                return $this->innerText();
             case 'text':
                 return $this->text();
             case 'tag':

--- a/src/PHPHtmlParser/Dom/HtmlNode.php
+++ b/src/PHPHtmlParser/Dom/HtmlNode.php
@@ -27,6 +27,13 @@ class HtmlNode extends InnerNode
     protected $outerHtml = null;
 
     /**
+     * Remembers what the innerText was if it was scanned previously.
+     * 
+     * @var ?string
+     */
+    protected $innerText = null;
+
+    /**
      * Remembers what the text was if it was scanned previously.
      *
      * @var ?string
@@ -109,6 +116,21 @@ class HtmlNode extends InnerNode
         $this->innerHtml = $string;
 
         return $string;
+    }
+
+    /**
+     * Gets the inner text of this node.
+     * @return string
+     * @throws ChildNotFoundException
+     * @throws UnknownChildTypeException
+     */
+    public function innerText(): string
+    {
+        if (is_null($this->innerText)) {
+            $this->innerText = strip_tags($this->innerHtml());
+        }
+
+        return $this->innerText;
     }
 
     /**

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -354,6 +354,16 @@ class DomTest extends TestCase {
         $this->assertEquals(2, $dom->countChildren());
     }
 
+    public function testInnerText()
+    {
+        $html = <<<EOF
+<body class="" style="" data-gr-c-s-loaded="true">123<a>456789</a><span>101112</span></body>
+EOF;
+        $dom = new Dom();
+        $dom->load($html);
+        $this->assertEquals($dom->innerText, "123456789101112");
+    }
+
     public function testGetChildrenArray()
     {
         $dom = new Dom;

--- a/tests/Node/HtmlTest.php
+++ b/tests/Node/HtmlTest.php
@@ -316,6 +316,20 @@ class NodeHtmlTest extends TestCase {
         $this->assertEquals('link', $node->text);
     }
 
+    public function testInnerText()
+    {
+        $node = new HtmlNode('div');
+        $node->addChild(new TextNode('123 '));
+        $anode = new HtmlNode('a');
+        $anode->addChild(new TextNode('456789 '));
+        $span_node = new HtmlNode('span');
+        $span_node->addChild(new TextNode('101112'));
+
+        $node->addChild($anode);
+        $node->addChild($span_node);
+        $this->assertEquals($node->innerText(), '123 456789 101112');
+    }
+
     public function testTextLookInChildren()
     {
         $p = new HtmlNode('p');


### PR DESCRIPTION
related: #222 

### Examples:

```html
<html>
  <head></head>
  <body class="" style="" data-gr-c-s-loaded="true">
123
   <a>456789</a>     
   <span>101112</span>
</body>
<html>
```

```javascript
document.body.innerText;
```

output
```
123 456789 101112
```

```PHP
$html = <<<EOF
  <body class="" style="" data-gr-c-s-loaded="true">
123
   <a>456789</a>     
   <span>101112</span>
</body>
EOF;
$dom = new Dom();
$dom->load($html);
echo $dom->innerText;
```

asset output
```
123 456789 101112
```