### PR TITLE
[dev/3.0.0]feature: innerText property support

### DIFF
--- a/src/PHPHtmlParser/Dom/Node/AbstractNode.php
+++ b/src/PHPHtmlParser/Dom/Node/AbstractNode.php
@@ -114,6 +114,8 @@ abstract class AbstractNode
                 return $this->outerHtml();
             case 'innerhtml':
                 return $this->innerHtml();
+            case 'innertext':
+                return $this->innerText();
             case 'text':
                 return $this->text();
             case 'tag':

--- a/src/PHPHtmlParser/Dom/Node/HtmlNode.php
+++ b/src/PHPHtmlParser/Dom/Node/HtmlNode.php
@@ -28,6 +28,13 @@ class HtmlNode extends InnerNode
     protected $outerHtml;
 
     /**
+     * Remembers what the innerText was if it was scanned previously.
+     * 
+     * @var ?string
+     */
+    protected $innerText = null;
+
+    /**
      * Remembers what the text was if it was scanned previously.
      *
      * @var ?string
@@ -109,6 +116,21 @@ class HtmlNode extends InnerNode
         $this->innerHtml = $string;
 
         return $string;
+    }
+
+    /**
+     * Gets the inner text of this node.
+     * @return string
+     * @throws ChildNotFoundException
+     * @throws UnknownChildTypeException
+     */
+    public function innerText(): string
+    {
+        if (is_null($this->innerText)) {
+            $this->innerText = strip_tags($this->innerHtml());
+        }
+
+        return $this->innerText;
     }
 
     /**

--- a/tests/DomTest.php
+++ b/tests/DomTest.php
@@ -330,6 +330,16 @@ class DomTest extends TestCase
         $this->assertEquals(1, \count($items));
     }
 
+    public function testInnerText()
+    {
+        $html = <<<EOF
+<body class="" style="" data-gr-c-s-loaded="true">123<a>456789</a><span>101112</span></body>
+EOF;
+        $dom = new Dom();
+        $dom->loadStr($html);
+        $this->assertEquals($dom->innerText, "123456789101112");
+    }
+
     public function testMultipleSquareSelector()
     {
         $dom = new Dom();

--- a/tests/Node/HtmlTest.php
+++ b/tests/Node/HtmlTest.php
@@ -323,6 +323,20 @@ class NodeHtmlTest extends TestCase
         $this->assertEquals('Please click me!', $node->text(true));
     }
 
+    public function testInnerText()
+    {
+        $node = new HtmlNode('div');
+        $node->addChild(new TextNode('123 '));
+        $anode = new HtmlNode('a');
+        $anode->addChild(new TextNode('456789 '));
+        $span_node = new HtmlNode('span');
+        $span_node->addChild(new TextNode('101112'));
+
+        $node->addChild($anode);
+        $node->addChild($span_node);
+        $this->assertEquals($node->innerText(), '123 456789 101112');
+    }
+
     public function testTextLookInChildrenAndNoChildren()
     {
         $p = new HtmlNode('p');


### PR DESCRIPTION
related: #222

related: #225 

```html
<html>
  <head></head>
  <body class="" style="" data-gr-c-s-loaded="true">
123
   <a>456789</a>
   <span>101112</span>
</body>
<html>
```

```javascript
document.body.innerText;
```

output
```
123 456789 101112
```

```PHP
$html = <<<EOF
  <body class="" style="" data-gr-c-s-loaded="true">
123
   <a>456789</a>
   <span>101112</span>
</body>
EOF;
$dom = new Dom();
$dom->load($html);
echo $dom->innerText;
```

asset output
```
123 456789 101112
```