### PR TITLE
chore: also support guzzlehttp/guzzle 6.x & 7.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-curl": "*",
         "paquettg/string-encode": "~1.0.0",
         "php-http/httplug": "^2.1",
-        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/guzzle": "^6.3.1|^7.0.1",
         "guzzlehttp/psr7": "^1.6",
         "myclabs/php-enum": "^1.7"
     },


### PR DESCRIPTION
same dependencies to laravel/framework 8 suggest: