### PR TITLE
Fix for str_replace()

### DIFF
--- a/src/PHPHtmlParser/Dom/Node/TextNode.php
+++ b/src/PHPHtmlParser/Dom/Node/TextNode.php
@@ -53,6 +53,9 @@ class TextNode extends LeafNode
             if ($replacedText === false) {
                 throw new LogicalException('mb_ereg_replace returns false when attempting to clean white space from "' . $text . '".');
             }
+            if ($replacedText === null) {
+                throw new LogicalException('mb_ereg_replace encountered an invalid encoding for "' . $text . '".');
+            }
             $text = $replacedText;
         }
 


### PR DESCRIPTION
Error:
`TypeError: str_replace(): Argument #3 ($subject) must be of type array|string, null given`