### PR TITLE
Fixed Collection::offsetGet() signature for PHP 8.1

### DIFF
--- a/src/PHPHtmlParser/Dom/Node/Collection.php
+++ b/src/PHPHtmlParser/Dom/Node/Collection.php
@@ -130,6 +130,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->collection[$offset] ?? null;


### PR DESCRIPTION
Fixes #290 