### PR TITLE
Fix parsing html with tag that has 'tag' attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vladshut/php-html-parser",
+    "name": "paquettg/php-html-parser",
     "type": "library",
     "description": "An HTML DOM parser. It allows you to manipulate HTML. Find tags on an HTML page with selectors just like jQuery.",
     "keywords": ["html", "dom", "parser"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "paquettg/php-html-parser",
+    "name": "vladshut/php-html-parser",
     "type": "library",
     "description": "An HTML DOM parser. It allows you to manipulate HTML. Find tags on an HTML page with selectors just like jQuery.",
     "keywords": ["html", "dom", "parser"],

--- a/src/PHPHtmlParser/Dom/Parser.php
+++ b/src/PHPHtmlParser/Dom/Parser.php
@@ -37,7 +37,7 @@ class Parser implements ParserInterface
         $root->setHtmlSpecialCharsDecode($options->isHtmlSpecialCharsDecode());
         $activeNode = $root;
         while ($activeNode !== null) {
-            if ($activeNode && $activeNode->tag->name() === 'script'
+            if ($activeNode && $activeNode->getTag()->name() === 'script'
                 && $options->isCleanupInput() !== true
             ) {
                 $str = $content->copyUntil('</');


### PR DESCRIPTION
Fix parsing html with tag that has 'tag' attribute.
Now it you will try to parse html like `<html><body tag="body"></body></html>` it fails.