### PR TITLE
Fix parsing html with tag that has 'tag' attribute

### DIFF
--- a/src/PHPHtmlParser/Dom/Parser.php
+++ b/src/PHPHtmlParser/Dom/Parser.php
@@ -37,7 +37,7 @@ class Parser implements ParserInterface
         $root->setHtmlSpecialCharsDecode($options->isHtmlSpecialCharsDecode());
         $activeNode = $root;
         while ($activeNode !== null) {
-            if ($activeNode && $activeNode->tag->name() === 'script'
+            if ($activeNode && $activeNode->getTag()->name() === 'script'
                 && $options->isCleanupInput() !== true
             ) {
                 $str = $content->copyUntil('</');


### PR DESCRIPTION
Fix parsing html with tag that has 'tag' attribute.
Now it you will try to parse html like `<html><body tag="body"></body></html>` it fails.