### PR TITLE
Allow use of v2 of Guzzle PSR-7 lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "paquettg/string-encode": "~1.0.0",
         "php-http/httplug": "^2.1",
         "guzzlehttp/guzzle": "^7.0",
-        "guzzlehttp/psr7": "^1.6",
+        "guzzlehttp/psr7": "^1.6 || ^2",
         "myclabs/php-enum": "^1.7"
     },
     "require-dev": {


### PR DESCRIPTION
For what's being used in this library, nothing changes between v1 and v2 of guzzlehttp/psr7 so we don't need to prevent this library from being used with the latter.