### PR TITLE
Added return type to offsetGet method

### DIFF
--- a/src/PHPHtmlParser/Dom/Node/Collection.php
+++ b/src/PHPHtmlParser/Dom/Node/Collection.php
@@ -130,7 +130,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->collection[$offset] ?? null;
     }


### PR DESCRIPTION
Added return type to offsetGet method in PHPHtmlParser/Dom/Node/Collection class
in order to fix deprecation notice caused by return type mismatch between the class and ArrayAccess interface