### PR TITLE
Deprecated: Return type php 8

### DIFF
--- a/src/PHPHtmlParser/Dom/Node/Collection.php
+++ b/src/PHPHtmlParser/Dom/Node/Collection.php
@@ -130,7 +130,7 @@ class Collection implements IteratorAggregate, ArrayAccess, Countable
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->collection[$offset] ?? null;
     }


### PR DESCRIPTION
Deprecated: Return type of PHPHtmlParser\Dom\Node\Collection::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/wp-content/plugins/sage/vendor/paquettg/php-html-parser/src/PHPHtmlParser/Dom/Node/Collection.php on line 133