### PR TITLE
Fix text value if mb_ereg_replace return null.

### DIFF
--- a/src/PHPHtmlParser/Dom/Node/TextNode.php
+++ b/src/PHPHtmlParser/Dom/Node/TextNode.php
@@ -53,7 +53,7 @@ class TextNode extends LeafNode
             if ($replacedText === false) {
                 throw new LogicalException('mb_ereg_replace returns false when attempting to clean white space from "' . $text . '".');
             }
-            $text = $replacedText;
+            $text = $replacedText ?: '';
         }
 
         // restore line breaks


### PR DESCRIPTION
Prevent fatal error if mb_ereg_replace return null instead of string.